### PR TITLE
Declare 12.0.5 support in toc

### DIFF
--- a/DataStore_Auctions/DataStore_Auctions.toc
+++ b/DataStore_Auctions/DataStore_Auctions.toc
@@ -1,4 +1,4 @@
-## Interface: 120000, 50501
+## Interface: 120000, 50501, 120005
 ## Title: DataStore_Auctions
 ## IconTexture: Interface\Icons\garrison_building_storehouse
 


### PR DESCRIPTION
## Summary
- Adds 120005 to the Interface field so the addon loads cleanly on WoW retail 12.0.5 (Midnight) without triggering the out-of-date warning.
- No code changes.

## Test plan
- [ ] Addon loads in 12.0.5 client without "Load out of date AddOns" required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)