### PR TITLE
Stop nagging about auctions that no longer exist

### DIFF
--- a/DataStore_Auctions/API/Common.lua
+++ b/DataStore_Auctions/API/Common.lua
@@ -124,10 +124,15 @@ local function CheckExpiries()
 	
 	for charID, character in pairs(allCharacters) do
 		-- Check if the last auction visit was maybe a very long time ago, and warn the player that he may have missed items..
-		if checkLastVisit and character.lastAuctionsScan then
+		-- Only fire the reminder if the character still has tracked auctions or bids — once everything
+		-- has expired or been cleared, the stale lastAuctionsScan timestamp shouldn't keep nagging.
+		local hasTrackedItems = (auctionsList[charID] and #auctionsList[charID] > 0)
+			or (bidsList[charID] and #bidsList[charID] > 0)
+
+		if checkLastVisit and character.lastAuctionsScan and hasTrackedItems then
 			local seconds = time() - character.lastAuctionsScan
 			local days = floor(seconds / 86400)
-			
+
 			AddonFactory:Broadcast("DATASTORE_AUCTIONS_NOT_CHECKED_SINCE", character, charID, days, threshold)
 		end
 		


### PR DESCRIPTION
`CheckExpiries` broadcasts `DATASTORE_AUCTIONS_NOT_CHECKED_SINCE` for every character whose `lastAuctionsScan` timestamp is set, regardless of whether any auctions or bids are still tracked. Users whose auctions have all expired or sold (and have been auto-cleared, or were never re-scanned) keep getting the reminder forever.

This patch only broadcasts when the character still has at least one tracked auction or bid — the stale timestamp alone is no longer enough.

Fixes Thaoky/Altoholic_Retail#73.